### PR TITLE
New fix for spaces before the comma in EXTINF rows with no attributes

### DIFF
--- a/ipytv/doctor.py
+++ b/ipytv/doctor.py
@@ -59,9 +59,29 @@ class M3UDoctor:
         return fixed_m3u_rows
 
     @staticmethod
+    def _fix_space_before_comma(m3u_rows: List[str]) -> List:
+        """
+        This covers the case of EXTINF rows with no attributes, but with one or more spaces between the comma and the
+        channel name.
+        Example:
+            #EXTINF:-1 ,Channel 22
+        """
+        spaces_before_comma_regex = r"^#EXTINF:(?P<duration_g>[-0-9\.]+)(?P<spaces_g>\s)+,(?P<name_g>.*)"
+        fixed_m3u_rows: List = []
+        for current_row in m3u_rows:
+            new_row = current_row
+            match = re.match(spaces_before_comma_regex, current_row)
+            if m3u.is_extinf_row(current_row) and match:
+                new_row = f"#EXTINF:{match.group('duration_g')},{match.group('name_g')}"
+            fixed_m3u_rows.append(new_row)
+        return fixed_m3u_rows
+
+
+    @staticmethod
     def sanitize(m3u_rows: List) -> List:
         fixed = M3UDoctor._fix_split_quoted_string(m3u_rows)
         fixed = M3UDoctor._fix_unquoted_numeric_attributes(fixed)
+        fixed = M3UDoctor._fix_space_before_comma(fixed)
         return fixed
 
 

--- a/ipytv/doctor.py
+++ b/ipytv/doctor.py
@@ -70,9 +70,10 @@ class M3UDoctor:
         fixed_m3u_rows: List = []
         for current_row in m3u_rows:
             new_row = current_row
-            match = re.match(spaces_before_comma_regex, current_row)
-            if m3u.is_extinf_row(current_row) and match:
-                new_row = f"#EXTINF:{match.group('duration_g')},{match.group('name_g')}"
+            if m3u.is_extinf_row(current_row):
+                match = re.match(spaces_before_comma_regex, current_row)
+                if match:
+                    new_row = f"#EXTINF:{match.group('duration_g')},{match.group('name_g')}"
             fixed_m3u_rows.append(new_row)
         return fixed_m3u_rows
 

--- a/ipytv/m3u.py
+++ b/ipytv/m3u.py
@@ -89,7 +89,7 @@ def is_comment_or_tag_row(row: str) -> bool:
 
 
 def is_empty_row(row: str) -> bool:
-    return len(row.strip()) == 0
+    return not row.strip()
 
 
 def is_url_row(row: str) -> bool:

--- a/tests/doctor_test.py
+++ b/tests/doctor_test.py
@@ -144,5 +144,23 @@ class TestSanitizeAllAttributes(unittest.TestCase):
         self.assertEqual(expected, fixed_pl)
 
 
+class TestSanitizeDuration(unittest.TestCase):
+    def runTest(self):
+        pl = playlist.loadl(test_data.space_before_comma.split("\n"))
+        self.assertEqual(4, pl.length())
+        for index in range(4):
+            # Before sanitizing the playlist, neither the duration nor the name of the channels are parsed correctly
+            duration = abs(int(float(pl.get_channel(index).duration)))
+            self.assertNotEqual(index+10, duration)
+            self.assertNotEqual(f"channel name {index}", pl.get_channel(index).name)
+        fixed = M3UDoctor.sanitize(test_data.space_before_comma.split("\n"))
+        pl = playlist.loadl(fixed)
+        for index in range(4):
+            # After sanitizing the playlist, both the duration and the name of the channels are parsed correctly
+            duration = abs(int(float(pl.get_channel(index).duration)))
+            self.assertEqual(index+10, duration)
+            self.assertEqual(f"channel name {index}", pl.get_channel(index).name)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -158,11 +158,11 @@ expected_attributes_broken_extinf_row = {
 space_before_comma = """#EXTM3U url-tvg="http://epg.51zmt.top:8000/e.xml" catchup="append" catchup-source="?playseek=${(b)yyyyMMddHHmmss}-${(e)yyyyMMddHHmmss}"
 
 #EXTINF:10 ,channel name 0
-http://[2409:8087:2001:20:2800:0:df6e:eb11]/ott.mobaibox.com/PLTV/3/224/3221228242/index.m3u8
+http://myown.link:80/luke/109163/78280
 #EXTINF:-11  ,channel name 1
-http://ainm.cc/a/play/php/cctv4k.php?id=4khd
+http://myown.link:80/luke/109163/78281
 #EXTINF:12 ,channel name 2
-http://[2409:8087:2001:20:2800:0:df6e:eb13]/ott.mobaibox.com/PLTV/3/224/3221228228/index.m3u8
+http://myown.link:80/luke/109163/78282
 #EXTINF:13.0   ,channel name 3
-http://r.jdshipin.com/krMB5
+http://myown.link:80/luke/109163/78283
 """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -154,3 +154,15 @@ expected_attributes_broken_extinf_row = {
     'tvg-logo': 'https://img.mysite.net/5425.jpg',
     'group-title': 'free, stream'
 }
+
+space_before_comma = """#EXTM3U url-tvg="http://epg.51zmt.top:8000/e.xml" catchup="append" catchup-source="?playseek=${(b)yyyyMMddHHmmss}-${(e)yyyyMMddHHmmss}"
+
+#EXTINF:10 ,channel name 0
+http://[2409:8087:2001:20:2800:0:df6e:eb11]/ott.mobaibox.com/PLTV/3/224/3221228242/index.m3u8
+#EXTINF:-11  ,channel name 1
+http://ainm.cc/a/play/php/cctv4k.php?id=4khd
+#EXTINF:12 ,channel name 2
+http://[2409:8087:2001:20:2800:0:df6e:eb13]/ott.mobaibox.com/PLTV/3/224/3221228228/index.m3u8
+#EXTINF:13.0   ,channel name 3
+http://r.jdshipin.com/krMB5
+"""


### PR DESCRIPTION
This covers the case of EXTINF rows with no attributes, but with one or more spaces between the comma and the channel name.
Example:
```
#EXTINF:-1 ,Channel 22
```
After the fix, the row above will become:
```
#EXTINF:-1,Channel 22
```