### PR TITLE
Fix empty playlist bug

### DIFF
--- a/ipytv/playlist.py
+++ b/ipytv/playlist.py
@@ -376,10 +376,11 @@ def loadl(rows: List) -> 'M3UPlaylist':
     if not isinstance(rows, List):
         log.error("expected %s, got %s", type([]), type(rows))
         raise WrongTypeException("Wrong type: List expected")
-    if len(rows) < 2:
-        log.error("a playlist should have at least 2 rows (found %s)", len(rows))
-        raise MalformedPlaylistException(f"a playlist should have at least 2 rows (found {len(rows)})")
     rows = _remove_blank_rows(rows)
+    pl_len = len(rows)
+    if pl_len < 1:
+        log.error("a playlist should have at least 1 row")
+        raise MalformedPlaylistException("a playlist should have at least 1 row")
     header = rows[0].strip()
     if not m3u.is_m3u_header_row(header):
         log.error(
@@ -390,6 +391,9 @@ def loadl(rows: List) -> 'M3UPlaylist':
         raise MalformedPlaylistException(f"Missing or misplaced {M3U_HEADER_TAG} row")
     out_pl = M3UPlaylist()
     out_pl.add_attributes(_parse_header(header))
+    # We're parsing an empty playlist, so we return an empty playlist object
+    if not pl_len > 1:
+        return out_pl
     cores = mp.cpu_count()
     log.debug("%s cores detected", cores)
     body = rows[1:]

--- a/tests/playlist_test.py
+++ b/tests/playlist_test.py
@@ -145,6 +145,12 @@ class TestLoadlM3UPlusHuge(unittest.TestCase):
         self.assertEqual(expected_length, pl.length(), "The size of the playlist is not the expected one")
 
 
+class TestLoadlM3UPlusEmptyPlaylist(unittest.TestCase):
+    def runTest(self):
+        pl = playlist.loadl(["#EXTM3U", ""])
+        self.assertEqual(0, pl.length(), "The size of the playlist is not the expected one")
+
+
 class TestLoadlM3UPlusWithExtras(unittest.TestCase):
     def runTest(self):
         checks: List[Dict[str, List[str]]] = [
@@ -253,6 +259,24 @@ class TestLoaduM3UPlus(unittest.TestCase):
         httpretty.disable()
         httpretty.reset()
         self.assertEqual(test_data.expected_m3u_plus, pl, "The two playlists are not equal")
+
+
+class TestLoaduM3UPlusWithEmptyPlaylist(unittest.TestCase):
+    def runTest(self):
+        url = "http://myown.link:80/luke/playlist.m3u"
+        body = "#EXTM3U\n"
+        with httpretty.enabled():
+            httpretty.register_uri(
+                httpretty.GET,
+                url,
+                adding_headers={"Content-Type": "application/octet-stream"},
+                body=body,
+                status=200
+            )
+            pl = playlist.loadu(url)
+        httpretty.disable()
+        httpretty.reset()
+        self.assertEqual(0, pl.length(), "Expected an empty playlist")
 
 
 class TestLoaduM3U8(unittest.TestCase):


### PR DESCRIPTION
When any of the `playlist.load*` functions is passed an empty playlist like the following:
```
#EXTM3U

```
the library fails with an `IndexError: list index out of range` error.